### PR TITLE
Update export-eval.sh

### DIFF
--- a/export-eval.sh
+++ b/export-eval.sh
@@ -12,7 +12,7 @@ cd "$dir"
 
 echo "Counting evals in $file"
 
-evals=$(tail -n +2 "$file" | wc -l)
+evals=$(tail -n +1 "$file" | wc -l)
 echo "$evals" >eval-count.txt
 
 echo "Compressing $evals evals to $compressed_file"


### PR DESCRIPTION
Corrects the total number of evals generated by the script. Current count is off by 1 because counting starts at second rather than first line.

Fixes https://github.com/lichess-org/database/issues/62