### PR TITLE
change chesspecker link to github repo

### DIFF
--- a/web/index.html.tpl
+++ b/web/index.html.tpl
@@ -437,7 +437,7 @@
               <a href="https://tusharmurali.github.io/chess-memory/">Puzzle memory trainer</a>
             </li>
             <li>
-              <a href="https://www.chesspecker.com">Chesspecker - puzzle repetition training</a>
+              <a href="https://github.com/chesspecker/chesspecker">Chesspecker - puzzle repetition training</a>
             </li>
             <li>
               <a href="https://lichess.org/@/piazzai/blog/do-variants-help-you-play-better-chess-statistical-evidence/0tAPXnqH">Do Variants Help You Play Better Chess?</a>


### PR DESCRIPTION
the chesspecker website https://www.chesspecker.com/ hasn't been working for some time (I think at least for a year), but instead of removing the entry completely, we could maybe change the link to the still existing github repo