### PR TITLE
Add Chessboard.fun to Related projects

### DIFF
--- a/web/index.html.tpl
+++ b/web/index.html.tpl
@@ -538,6 +538,9 @@
             <li>
               <a href="https://www.youtube.com/watch?v=oUERPFqruYo/">500,000 games of intermediate chess players analyzed (in French)</a>
             </li>
+            <li>
+              <a href="https://chessboard.fun/">Chessboard.fun</a> – Interactive chess training platform with puzzles, analysis, and stats
+            </li>
           </ul>
           <p>
             Did you use this database? Please share your results! contact@lichess.org


### PR DESCRIPTION
Adds Chessboard.fun to the Related projects section. Chessboard.fun is an interactive chess training platform with unique puzzle modes, statistics, and analysis, powered by Lichess API and puzzles database.