### PR TITLE
Add blitztactics.com link to related projects

### DIFF
--- a/web/index.html.tpl
+++ b/web/index.html.tpl
@@ -541,6 +541,9 @@
             <li>
               <a href="https://chessboard.fun/">Chessboard.fun</a> – Interactive chess training platform with puzzles, analysis, and stats
             </li>
+            <li>
+              <a href="https://blitztactics.com/">Blitz tactics - Fast-paced chess puzzles</a>
+            </li>
           </ul>
           <p>
             Did you use this database? Please share your results! contact@lichess.org


### PR DESCRIPTION
https://blitztactics.com/ is a chess puzzle website that started using lichess puzzles long ago. It's been recently updated to use puzzles from the latest lichess open database.